### PR TITLE
ci: include samplomatic in development version tests

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -66,6 +66,7 @@ jobs:
           extremal-python-dependencies pin-dependencies --inplace
           "qiskit @ file:$(echo qiskit/dist/*.whl)"
           "qiskit-ibm-runtime @ file:$(echo qiskit-ibm-runtime/dist/*.whl)"
+          "samplomatic @ file:$(echo samplomatic/dist/*.whl)"
           "qiskit-addon-utils @ file:$(echo qiskit-addon-utils/dist/*.whl)"
       - name: Test using tox environment
         run: |


### PR DESCRIPTION
This adds `samplomatic` as one of the upstream dependencies against whose `main` branch we test during the development version tests running in CI. This is important because of samplomatic's early development stage and tight coupling with some of Qiskit's newest (and currently being refactored) features.

A good example is #17 which led to this chain:
- https://github.com/Qiskit/qiskit/issues/15409
- https://github.com/Qiskit/samplomatic/issues/251
- https://github.com/Qiskit/samplomatic/pull/252

By testing against `samplomatic`'s `main` branch now, we can verify whether the SLC addon will continue to work properly with the changes above being synchronized across versions.