### PR TITLE
fix: hard-code the twirling_strategy

### DIFF
--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -44,7 +44,9 @@ def test_noise_model_paulis() -> None:
     AddInjectNoise._MODIFIER_REF_COUNTER = count()
 
     boxes_pm = generate_boxing_pass_manager(
-        inject_noise_targets="all", inject_noise_strategy="individual_modification"
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        twirling_strategy="active",
     )
     boxed_circ = boxes_pm.run(circ)
 

--- a/tests/utils/test_circuit_iter.py
+++ b/tests/utils/test_circuit_iter.py
@@ -46,7 +46,9 @@ def test_circuit_iter() -> None:
     AddInjectNoise._MODIFIER_REF_COUNTER = count()
 
     boxes_pm = generate_boxing_pass_manager(
-        inject_noise_targets="all", inject_noise_strategy="individual_modification"
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        twirling_strategy="active",
     )
     boxed_circ = boxes_pm.run(circ)
 

--- a/tests/utils/test_noise_model_paulis.py
+++ b/tests/utils/test_noise_model_paulis.py
@@ -51,7 +51,9 @@ def test_noise_model_paulis(subtests, num_qubits: int) -> None:
         circ.cx(idx - 1, idx)
 
     boxes_pm = generate_boxing_pass_manager(
-        inject_noise_targets="all", inject_noise_strategy="individual_modification"
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        twirling_strategy="active",
     )
     boxed_circ = boxes_pm.run(circ)
 
@@ -120,7 +122,9 @@ def test_noise_model_paulis_with_backend(subtests) -> None:
     isa_circ = preset_pm.run(circ)
 
     boxes_pm = generate_boxing_pass_manager(
-        inject_noise_targets="all", inject_noise_strategy="individual_modification"
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        twirling_strategy="active",
     )
     boxed_circ = boxes_pm.run(isa_circ)
 


### PR DESCRIPTION
Samplomatic changed the default `twirling_strategy` in its development branch. We wish to enforce the older default in our test suite until we can have more control of non-entangling gate placement into other boxes.

See https://github.com/Qiskit/samplomatic/pull/265 for the changed default in samplomatic.
See https://github.com/Qiskit/samplomatic/issues/267 for more details regarding the gate placement conventions.