### PR TITLE
fix div-by-zero for small circuit

### DIFF
--- a/qiskit_addon_slc/bounds/commutator_bounds.py
+++ b/qiskit_addon_slc/bounds/commutator_bounds.py
@@ -230,7 +230,7 @@ def compute_bounds(
 
     progress_polling_rate = 1
     len_progress_indicator = 50
-    per_progress_char = total_num_tasks // len_progress_indicator
+    per_progress_char = total_num_tasks / len_progress_indicator
 
     try:
         while tasks:
@@ -238,7 +238,7 @@ def compute_bounds(
             tasks = {t for t in tasks if not t.ready()}
             completed = total_num_tasks - len(tasks)
             perc = (completed / total_num_tasks) * 100
-            progress = "." * (completed // per_progress_char)
+            progress = "." * int(completed / per_progress_char)
             LOGGER.info(
                 f"Progress: {progress:{len_progress_indicator}} "
                 f"[{completed}/{total_num_tasks}] {perc:.1f}%"


### PR DESCRIPTION
Fixes a divide-by-zero bug in computing how many hyphens to print in the progress bar.

For a small circuit (e.g. a minimal debugging test case), `per_progress_char` (the number of tasks to complete before adding another hyphen to the progress bar) can get rounded down to `0`, leading to a divide-by-zero error. This commit fixes this by delaying conversion to an integer until necessary.