### PR TITLE
Use machine precision as tolerance during propagation

### DIFF
--- a/docs/apidocs/index.rst
+++ b/docs/apidocs/index.rst
@@ -6,5 +6,6 @@
    :maxdepth: 1
 
    qiskit_addon_slc.bounds
+   qiskit_addon_slc.globals
    qiskit_addon_slc.utils
    qiskit_addon_slc.visualization

--- a/docs/apidocs/qiskit_addon_slc.globals.rst
+++ b/docs/apidocs/qiskit_addon_slc.globals.rst
@@ -1,0 +1,8 @@
+=========================================
+Globals (:mod:`qiskit_addon_slc.globals`)
+=========================================
+
+.. automodule:: qiskit_addon_slc.globals
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from functools import partial
 
 import numpy as np
@@ -34,6 +33,7 @@ from qiskit.quantum_info import (
     SparsePauliOp,
 )
 
+from ..globals import ZERO_ATOL
 from ..utils import remove_measure
 from .commutator_bounds import Bounds, CommutatorBounds, compute_bounds
 from .light_cone import LightCone
@@ -75,12 +75,11 @@ def _time_evolved_norm_backward(
     """
     # Convert the single Pauli to a SparsePauliOp which we can then evolve
     pauli = SparsePauliOp(pauli)
-    atol = sys.float_info.epsilon  # Machine precision of f64
     pauli, trunc_onenorm = propagate_through_rotation_gates(
         operator=pauli,
         rot_gates=gates,
         max_terms=evolution_max_terms,
-        atol=atol,
+        atol=ZERO_ATOL,
         frame="s",
     )
     trunc_bias = 2 * trunc_onenorm

--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from functools import partial
 
 import numpy as np
@@ -74,11 +75,12 @@ def _time_evolved_norm_backward(
     """
     # Convert the single Pauli to a SparsePauliOp which we can then evolve
     pauli = SparsePauliOp(pauli)
+    atol = sys.float_info.epsilon # Machine precision of f64
     pauli, trunc_onenorm = propagate_through_rotation_gates(
         operator=pauli,
         rot_gates=gates,
         max_terms=evolution_max_terms,
-        atol=0,
+        atol=atol,
         frame="s",
     )
     trunc_bias = 2 * trunc_onenorm

--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -75,7 +75,7 @@ def _time_evolved_norm_backward(
     """
     # Convert the single Pauli to a SparsePauliOp which we can then evolve
     pauli = SparsePauliOp(pauli)
-    atol = sys.float_info.epsilon # Machine precision of f64
+    atol = sys.float_info.epsilon  # Machine precision of f64
     pauli, trunc_onenorm = propagate_through_rotation_gates(
         operator=pauli,
         rot_gates=gates,

--- a/qiskit_addon_slc/bounds/forward.py
+++ b/qiskit_addon_slc/bounds/forward.py
@@ -36,6 +36,7 @@ from qiskit.quantum_info import (
     SparsePauliOp,
 )
 
+from ..globals import ZERO_ATOL
 from ..utils import get_extremal_eigenvalue, remove_measure
 from .commutator_bounds import Bounds, CommutatorBounds, compute_bounds
 from .light_cone import LightCone
@@ -88,7 +89,7 @@ def time_evolved_norm_forward(
         operator=pauli,
         rot_gates=gates,
         max_terms=evolution_max_terms,
-        atol=0,
+        atol=ZERO_ATOL,
         frame="s",
     )
     trunc_bias = 2 * trunc_onenorm

--- a/qiskit_addon_slc/globals.py
+++ b/qiskit_addon_slc/globals.py
@@ -1,0 +1,32 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Warning: this module is not documented and it does not have an RST file.
+# If we ever publicly expose interfaces users can import from this module,
+# we should set up its RST file.
+
+"""Global settings.
+
+.. currentmodule:: qiskit_addon_slc.globals
+
+This module provides a number of globally configurable settings.
+
+.. autoclass:: ZERO_ATOL
+"""
+
+import sys
+
+ZERO_ATOL = 10 * sys.float_info.epsilon
+"""The absolute tolerance value below which terms are considered truly zero and are truncated.
+
+This defaults to the value of ``10 * sys.float_info.epsilon``.
+"""

--- a/releasenotes/notes/truncate-numerically-zero-terms-c9d7e8e833901301.yaml
+++ b/releasenotes/notes/truncate-numerically-zero-terms-c9d7e8e833901301.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The pauli-propagation underlying the forward and backward-bound computations
+    has been adjusted to remove terms whose coefficients are numerically zero.
+    The truncation threshold to determine whether a term is numerically zero can
+    be adjusted via :attr:`qiskit_addon_slc.globals.ZERO_ATOL`.


### PR DESCRIPTION
This PR sets ``atol`` to f64 precision during back-propagation, rather than ``0.0``. This can give a meaningful speedup on problems where a large number of terms with tiny coeff values accumulate in the operators.