### PR TITLE
perf: introduce caching into LightCone.commutes

### DIFF
--- a/qiskit_addon_slc/bounds/light_cone.py
+++ b/qiskit_addon_slc/bounds/light_cone.py
@@ -52,6 +52,10 @@ class LightCone(NamedTuple):
     operations: list[tuple[Gate, list[Qubit]]]
     """The operations contained in the light cone."""
 
+    offset_cache: dict[tuple[str, tuple[float], tuple[Qubit]], int]
+    """A cache mapping circuit instructions to the offset in :attr:`.operations` up to which they
+    commute."""
+
     def commutes(self, inst: CircuitInstruction) -> bool:
         """Checks whether the provided instruction commutes with this light cone.
 
@@ -67,9 +71,12 @@ class LightCone(NamedTuple):
         if not self.qubits.intersection(inst.qubits):
             return True
 
+        cache_key = (inst.operation.name, tuple(inst.operation.params), inst.qubits)
+        offset = self.offset_cache.get(cache_key, 0)
+
         commutes_bool = True
         # Check commutation with all previous operations
-        for op in self.operations:
+        for op_idx, op in enumerate(self.operations[offset:]):  # noqa: B007
             if op[0].name == "pauli":
                 # PERF: When the operation stored inside the LightCone is a Pauli, we know how to
                 # reduce its size to consider only those qubits that actually overlap with the
@@ -107,6 +114,8 @@ class LightCone(NamedTuple):
                 commutes_bool = False
                 break
 
+        self.offset_cache[cache_key] = op_idx + offset
+
         return commutes_bool
 
     @classmethod
@@ -125,7 +134,7 @@ class LightCone(NamedTuple):
         bit_terms = str(pauli[mask])
         qargs = [circuit.qubits[i] for i in indices]
 
-        return cls(set(qargs), [(PauliGate(bit_terms), qargs)])
+        return cls(set(qargs), [(PauliGate(bit_terms), qargs)], {})
 
     @classmethod
     def initialize_from_measurements(
@@ -155,4 +164,4 @@ class LightCone(NamedTuple):
         else:
             raise NotImplementedError
 
-        return cls(set(qargs), [(ZGate(), [idx]) for idx in qargs])
+        return cls(set(qargs), [(ZGate(), [idx]) for idx in qargs], {})

--- a/tests/bounds/test_light_cone.py
+++ b/tests/bounds/test_light_cone.py
@@ -25,7 +25,7 @@ def test_zxz(subtests):
     """
     qubits = list([Qubit() for _ in range(3)])
     operations = [(PauliGate("ZXZ"), qubits)]
-    lc = LightCone(set(qubits), operations)
+    lc = LightCone(set(qubits), operations, {})
 
     with subtests.test("cz(0,2)"):
         assert lc.commutes(CircuitInstruction(CZGate(), (qubits[0], qubits[2])))
@@ -44,7 +44,7 @@ def test_zzz(subtests):
     """
     qubits = list([Qubit() for _ in range(3)])
     operations = [(PauliGate("ZZZ"), qubits)]
-    lc = LightCone(set(qubits), operations)
+    lc = LightCone(set(qubits), operations, {})
 
     with subtests.test("cz(0,2)"):
         assert lc.commutes(CircuitInstruction(CZGate(), (qubits[0], qubits[2])))


### PR DESCRIPTION
Whenever we re-encounter a `CircuitInstruction` and check whether it commutes with the `LightCone`, we are repeating a lot of commutation checks which (even though fast on their own) accumulate significant runtime when called millions of times.

This introduces a simple caching mechanism to avoid repetitive commutation checks.

---

Below is a simple example for how this improves the performance:

| Before | After |
|--------|--------|
| <img width="2360" height="1646" alt="image" src="https://github.com/user-attachments/assets/4e5c16db-15d7-475d-b275-f987f7f4bc46" /> | <img width="2360" height="1648" alt="image" src="https://github.com/user-attachments/assets/111d0fa3-a698-4ef6-b261-3b662812babf" /> | 

The time spent in `LightCone.commutes` reduces from 58.66% to 4.73% of the total runtime of the main thread.
Now we can make two observations:
- the remaining majority of the time of the main thread (which produces all the asynchronous tasks for the worker pool) is spend on `Pauli.evolve` (which happens [here](https://github.com/Qiskit/qiskit-addon-slc/blob/6e5ff3715913320f02a5481c39123ac7c34469fa/qiskit_addon_slc/bounds/commutator_bounds.py#L201))
- the time spend by the async worker pool waiting on completion of all remaning tasks _should_ in theory be possible to reduce through the increase of more worker threads. However in practice I'm noticing a diminishing return on investment i.e. increasing the number of threads arbitrarily on a large machine does not reduce runtime with equal scaling (i.e. I observe virtually no difference in runtime between 128 and 192 threads on a machine with 192 logical CPU cores). This is a separate issue to investigate.

---

Note that the `LightCone` object is not part of the public API which is why this PR does not require a release note and is not considered a breaking change.