### PR TITLE
feat: allow limiting the number of BoxOp for which to compute bounds

### DIFF
--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -103,6 +103,7 @@ def compute_backward_bounds(
     /,
     *,
     evolution_max_terms: int = 1_000_000,
+    max_num_boxes: int | None = None,
     num_processes: int = 1,
     timeout: float | None = None,
 ) -> Bounds:
@@ -132,6 +133,8 @@ def compute_backward_bounds(
         noise_model_paulis: the Pauli error terms to consider for each noise model.
         evolution_max_terms: the maximum number of operator terms to keep track of during the
             evolution. (If the operator exceeds this size, the smallest terms are truncated).
+        max_num_boxes: the maximum number of boxes for which to compute bounds. Bounds for any
+            additional boxes will be given the trivial upper bound value of :math:`2.0`.
         num_processes: the number of parallel processes to use.
         timeout: an optional timeout (in seconds) after which all remaining layers are filled with
             trivial numerical bounds of ``2.0``. Note, that this is not a strict timeout and the
@@ -158,6 +161,7 @@ def compute_backward_bounds(
         lc,
         norm_fn,
         backwards=True,
+        max_num_boxes=max_num_boxes,
         num_processes=num_processes,
         timeout=timeout,
     )

--- a/qiskit_addon_slc/bounds/commutator_bounds.py
+++ b/qiskit_addon_slc/bounds/commutator_bounds.py
@@ -90,6 +90,7 @@ def compute_bounds(
     norm_fn: Callable[[Pauli, RotationGates], CommutatorBounds],
     *,
     backwards: bool,
+    max_num_boxes: int | None = None,
     num_processes: int = 1,
     timeout: float | None = None,
 ) -> Bounds:
@@ -112,6 +113,8 @@ def compute_bounds(
         light_cone: the initialized and stateful :class:`.LightCone` tracker.
         norm_fn: the function implementing the specific unequal time commutator.
         backwards: whether to iterate over the ``circuit`` in reverse.
+        max_num_boxes: the maximum number of boxes for which to compute bounds. Bounds for any
+            additional boxes will be given the trivial upper bound value of :math:`2.0`.
         num_processes: the number of parallel processes to use.
         timeout: an optional timeout (in seconds) after which all remaining layers are filled with
             trivial numerical bounds of ``2.0``. Note, that this is not a strict timeout and the
@@ -172,6 +175,8 @@ def compute_bounds(
     start = time.time()
     LOGGER.info("Starting to spawn bound computation tasks")
 
+    encountered_num_boxes = 0
+
     for circ_inst, qargs, box_id, noise_id in iter_circuit(circuit, reverse=True):
         if box_id is None:
             _handle_circuit_instruction(circ_inst)
@@ -181,7 +186,13 @@ def compute_bounds(
         assert noise_id is not None
 
         noise_terms: QubitSparsePauliList = noise_model_paulis[noise_id]
+        # pre-populate computed bounds with trivial upper bound
         gathered_bounds[box_id] = (np.full(len(noise_terms), 2.0), noise_terms)
+
+        encountered_num_boxes += 1
+        if max_num_boxes is not None and encountered_num_boxes > max_num_boxes:
+            # skipping actual bound computation and limiting bound estimate to trivial value
+            continue
 
         if backwards:
             # NOTE: we unroll the BoxOp immediately to allow gates contained within the box be

--- a/qiskit_addon_slc/bounds/forward.py
+++ b/qiskit_addon_slc/bounds/forward.py
@@ -198,6 +198,7 @@ def compute_forward_bounds(
     evolution_max_terms: int = 1_000_000,
     eigval_max_qubits: int = 14,
     atol: float = 1e-8,
+    max_num_boxes: int | None = None,
     num_processes: int = 1,
     timeout: float | None = None,
 ) -> Bounds:
@@ -226,6 +227,8 @@ def compute_forward_bounds(
             approximated via a simpler and more loose triangle inequality.
         atol: the absolute tolerance used for trimming terms from the commutator and for detecting
             convergence of the commutator's eigenvalue.
+        max_num_boxes: the maximum number of boxes for which to compute bounds. Bounds for any
+            additional boxes will be given the trivial upper bound value of :math:`2.0`.
         num_processes: the number of parallel processes to use.
         timeout: an optional timeout (in seconds) after which all remaining layers are filled with
             trivial numerical bounds of ``2.0``. Note, that this is not a strict timeout and the
@@ -276,6 +279,7 @@ def compute_forward_bounds(
         lc,
         norm_fn,
         backwards=False,
+        max_num_boxes=max_num_boxes,
         num_processes=num_processes,
         timeout=timeout,
     )

--- a/releasenotes/notes/max-num-boxes-a4d99e2eaf7fd505.yaml
+++ b/releasenotes/notes/max-num-boxes-a4d99e2eaf7fd505.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added the ``max_num_boxes`` argument to
+    :func:`~qiskit_addon_slc.bounds.compute_forward_bounds` and
+    :func:`~qiskit_addon_slc.bounds.compute_backward_bounds`. This new optional
+    setting will set the maximum number of :class:`~qiskit.circuit.BoxOp`
+    instructions for which to compute shaded light-cone bounds. Any remaining
+    boxes with an :class:`~samplomatic.InjectNoise` annotation will be given
+    trivial upper bounds of :math:`2.0`.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,43 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for SLC."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit import QuantumCircuit
+
+
+def construct_trotter_circuit(
+    num_qubits: int,
+    num_trotter_steps: int,
+    rx_angle: float,
+    rzz_angle: float,
+    use_clifford: bool = False,
+) -> QuantumCircuit:
+    circuit = QuantumCircuit(num_qubits)
+
+    for _ in range(num_trotter_steps):
+        circuit.rx(rx_angle, range(num_qubits))
+        circuit.barrier()
+        for first_qubit in (0, 1):
+            for idx in range(first_qubit, num_qubits - 1, 2):
+                if use_clifford:
+                    assert np.isclose(rzz_angle, -np.pi / 2)
+                    circuit.sdg([idx, idx + 1])
+                    circuit.cz(idx, idx + 1)
+                else:
+                    circuit.rzz(rzz_angle, idx, idx + 1)
+        circuit.barrier()
+
+    return circuit

--- a/tests/bounds/test_backward.py
+++ b/tests/bounds/test_backward.py
@@ -1,0 +1,97 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the backward bounds."""
+
+from __future__ import annotations
+
+import pickle
+import random
+from pathlib import Path
+
+import numpy as np
+from qiskit_addon_slc.bounds import compute_backward_bounds, merge_bounds
+from qiskit_addon_slc.bounds.trivial import trivial_bounds
+from qiskit_addon_slc.utils import generate_noise_model_paulis
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions
+
+from .. import construct_trotter_circuit
+
+RANDOM_SEED = 42
+
+
+def test_max_num_boxes():
+    """Test limiting the maximum number of BoxOps for which to compute backward bounds."""
+    np.random.seed(RANDOM_SEED)
+    random.seed(RANDOM_SEED)
+
+    num_qubits = 50
+    circuit = construct_trotter_circuit(
+        num_qubits=num_qubits,
+        num_trotter_steps=4,
+        rx_angle=np.pi / 16,
+        rzz_angle=-np.pi / 2,
+        use_clifford=False,
+    )
+
+    boxes_pm = generate_boxing_pass_manager(
+        enable_gates=True,
+        enable_measures=True,
+        twirling_strategy="active",
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        measure_annotations="all",
+        remove_barriers=False,
+    )
+    boxed_circuit = boxes_pm.run(circuit)
+
+    instructions = find_unique_box_instructions(boxed_circuit)
+
+    noise_model_paulis = generate_noise_model_paulis(instructions)
+
+    max_num_boxes = 2
+    backward_bounds = compute_backward_bounds(
+        boxed_circuit,
+        noise_model_paulis,
+        evolution_max_terms=2000,
+        max_num_boxes=max_num_boxes,
+    )
+
+    trivial = trivial_bounds(boxed_circuit, noise_model_paulis)
+
+    # NOTE: here one would get the the noise model rates from the NoiseLearner
+    noise_model_rates = {noise_id: None for noise_id in noise_model_paulis}
+
+    merged_bounds = merge_bounds(
+        boxed_circuit,
+        backward_bounds,
+        trivial,
+        noise_model_rates,
+        is_clifford_circuit=False,
+    )
+
+    with open(Path(__file__).parent.parent / "expected_bwd_bounds.pickle", "rb") as file:
+        actual_bwd_bounds = {box: bounds for box, bounds in merged_bounds.items()}
+        expected_bwd_bounds = pickle.load(file)
+        for idx, key in enumerate(expected_bwd_bounds):
+            assert key in actual_bwd_bounds
+            expected = (
+                np.full(len(expected_bwd_bounds[key]), 2.0)
+                if idx >= max_num_boxes
+                else expected_bwd_bounds[key]
+            )
+            assert np.allclose(actual_bwd_bounds[key].rates, expected)
+
+
+if __name__ == "__main__":
+    test_max_num_boxes()

--- a/tests/bounds/test_forward.py
+++ b/tests/bounds/test_forward.py
@@ -1,0 +1,103 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the forward bounds."""
+
+from __future__ import annotations
+
+import pickle
+import random
+from pathlib import Path
+
+import numpy as np
+from qiskit.quantum_info import Pauli
+from qiskit_addon_slc.bounds import compute_forward_bounds, merge_bounds
+from qiskit_addon_slc.bounds.trivial import trivial_bounds
+from qiskit_addon_slc.utils import generate_noise_model_paulis
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import find_unique_box_instructions
+
+from .. import construct_trotter_circuit
+
+RANDOM_SEED = 42
+
+
+def test_max_num_boxes():
+    """Test limiting the maximum number of BoxOps for which to compute forward bounds."""
+    np.random.seed(RANDOM_SEED)
+    random.seed(RANDOM_SEED)
+
+    num_qubits = 50
+    circuit = construct_trotter_circuit(
+        num_qubits=num_qubits,
+        num_trotter_steps=4,
+        rx_angle=np.pi / 16,
+        rzz_angle=-np.pi / 2,
+        use_clifford=False,
+    )
+
+    boxes_pm = generate_boxing_pass_manager(
+        enable_gates=True,
+        enable_measures=True,
+        twirling_strategy="active",
+        inject_noise_targets="all",
+        inject_noise_strategy="individual_modification",
+        measure_annotations="all",
+        remove_barriers=False,
+    )
+    boxed_circuit = boxes_pm.run(circuit)
+
+    instructions = find_unique_box_instructions(boxed_circuit)
+
+    noise_model_paulis = generate_noise_model_paulis(instructions)
+
+    obs_pauli = Pauli("I" * num_qubits).compose("XYZ", [12, 24, 36])
+
+    max_num_boxes = 2
+    forward_bounds = compute_forward_bounds(
+        boxed_circuit,
+        noise_model_paulis,
+        obs_pauli,
+        eigval_max_qubits=20,
+        evolution_max_terms=1000,
+        atol=1e-18,
+        max_num_boxes=max_num_boxes,
+    )
+
+    trivial = trivial_bounds(boxed_circuit, noise_model_paulis)
+
+    # NOTE: here one would get the the noise model rates from the NoiseLearner
+    noise_model_rates = {noise_id: None for noise_id in noise_model_paulis}
+
+    merged_bounds = merge_bounds(
+        boxed_circuit,
+        forward_bounds,
+        trivial,
+        noise_model_rates,
+        is_clifford_circuit=False,
+    )
+
+    with open(Path(__file__).parent.parent / "expected_fwd_bounds.pickle", "rb") as file:
+        actual_fwd_bounds = {box: bounds for box, bounds in merged_bounds.items()}
+        expected_fwd_bounds = pickle.load(file)
+        for idx, key in enumerate(expected_fwd_bounds):
+            assert key in actual_fwd_bounds
+            expected = (
+                np.full(len(expected_fwd_bounds[key]), 2.0)
+                if idx >= max_num_boxes
+                else expected_fwd_bounds[key]
+            )
+            assert np.allclose(actual_fwd_bounds[key].rates, expected)
+
+
+if __name__ == "__main__":
+    test_max_num_boxes()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -10,10 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Warning: this module is not documented and it does not have an RST file.
-# If we ever publicly expose interfaces users can import from this module,
-# we should set up its RST file.
-
 """End-to-end tests for the entire SLC bounds computation."""
 
 from __future__ import annotations
@@ -26,7 +22,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from qiskit import QuantumCircuit, transpile
+from qiskit import transpile
 from qiskit.quantum_info import Pauli, PauliLindbladMap, QubitSparsePauliList
 from qiskit_addon_slc.bounds import (
     compute_backward_bounds,
@@ -40,33 +36,10 @@ from samplomatic.transpiler import generate_boxing_pass_manager
 from samplomatic.transpiler.passes import AddInjectNoise
 from samplomatic.utils import find_unique_box_instructions
 
+from . import construct_trotter_circuit
+
 RANDOM_SEED = 42
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s %(message)s")
-
-
-def _construct_trotter_circuit(
-    num_qubits: int,
-    num_trotter_steps: int,
-    rx_angle: float,
-    rzz_angle: float,
-    use_clifford: bool = False,
-) -> QuantumCircuit:
-    circuit = QuantumCircuit(num_qubits)
-
-    for _ in range(num_trotter_steps):
-        circuit.rx(rx_angle, range(num_qubits))
-        circuit.barrier()
-        for first_qubit in (0, 1):
-            for idx in range(first_qubit, num_qubits - 1, 2):
-                if use_clifford:
-                    assert np.isclose(rzz_angle, -np.pi / 2)
-                    circuit.sdg([idx, idx + 1])
-                    circuit.cz(idx, idx + 1)
-                else:
-                    circuit.rzz(rzz_angle, idx, idx + 1)
-        circuit.barrier()
-
-    return circuit
 
 
 @pytest.mark.parametrize("use_clifford", [False, True])
@@ -85,7 +58,7 @@ def test_e2e(use_clifford: bool):
     AddInjectNoise._MODIFIER_REF_COUNTER = count()
 
     num_qubits = 50
-    circuit = _construct_trotter_circuit(
+    circuit = construct_trotter_circuit(
         num_qubits=num_qubits,
         num_trotter_steps=4,
         rx_angle=np.pi / 16,


### PR DESCRIPTION
A user might know upfront how deep into the circuit they are able to/want to propagate irrespective of the computational time associated with that. A particular example are circuits with certain structure resulting in the forward and backward bounds being used for either half of the circuit.

This PR introduces a `max_num_boxes` argument to the forward- and backward-bounds computation functions allowing a user to limit the depth up to which bound-computation tasks are spawned in the first place. The reason for limiting this "indirectly" via the number of `BoxOp` instructions is simple:
- it makes for an intuitive interface as it is related to the user-perceived depth of the circuit
- it avoids coupling to a `BoxOp`'s `InjectNoise` references which are auto-generated by samplomatic and not possible to predict ahead of time (plus they can change between repeated transpilation runs while the depth will not)