### PR TITLE
perf: bail early on commutator bound with exceeding truncation

### DIFF
--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -84,6 +84,9 @@ def _time_evolved_norm_backward(
     )
     trunc_bias = 2 * trunc_onenorm
 
+    if trunc_bias >= 2.0:
+        return CommutatorBounds(float("NaN"), trunc_bias, False)
+
     acts_on_zero = np.any(pauli.paulis.x, axis=1)
     x = pauli.paulis.x[acts_on_zero]
     z = pauli.paulis.z[acts_on_zero]

--- a/qiskit_addon_slc/bounds/commutator_bounds.py
+++ b/qiskit_addon_slc/bounds/commutator_bounds.py
@@ -61,6 +61,9 @@ class CommutatorBounds(NamedTuple):
     If the norm computation exceeds specified difficulty limits, it will be abandoned in favor of a
     simpler bound based on the triangle inequality, which is indicated by
     :attr:`fallback_to_tri_ineq` being set to ``True``.
+
+    This value may be ``NaN`` when the computation of the commutor bound was aborted. This can
+    happen when the :attr:`truncation_bias` already exceeds the theoretical bound of ``2.0``.
     """
 
     truncation_bias: float

--- a/qiskit_addon_slc/bounds/forward.py
+++ b/qiskit_addon_slc/bounds/forward.py
@@ -94,6 +94,9 @@ def time_evolved_norm_forward(
     )
     trunc_bias = 2 * trunc_onenorm
 
+    if trunc_bias >= 2.0:
+        return CommutatorBounds(float("NaN"), trunc_bias, False)
+
     # Handle case of a single-Pauli:
     # Ignore limit on num qubits since don't need to go to computational basis.
     # Efficiently handles Clifford case.
@@ -124,6 +127,9 @@ def time_evolved_norm_forward(
     one_norm_loss = one_norm_before - one_norm_after
     one_norm_loss = max(one_norm_loss, np.float64(0.0))
     trunc_bias += one_norm_loss
+
+    if trunc_bias >= 2.0:
+        return CommutatorBounds(float("NaN"), trunc_bias, False)
 
     # Handle case where commutator is 0:
     if np.logical_not(np.any((commutator.paulis.x, commutator.paulis.z))) and np.isclose(


### PR DESCRIPTION
When the truncation bias already exceeds the upper bound of 2.0, we can bail on the potentially costly computation of the commutator bound.