### PR TITLE
fix: hanlding of NaN value in bounds

### DIFF
--- a/qiskit_addon_slc/bounds/commutator_bounds.py
+++ b/qiskit_addon_slc/bounds/commutator_bounds.py
@@ -83,7 +83,7 @@ class CommutatorBounds(NamedTuple):
         The value of ``2.0`` is used because a Pauli observable bounded on the range
         ``[-1, +1]`` cannot be biased by more than ``2.0``.
         """
-        return min(self.commutator_bound + self.truncation_bias, 2.0)
+        return float(np.nanmin((self.commutator_bound + self.truncation_bias, 2.0)))
 
 
 def compute_bounds(


### PR DESCRIPTION
#68 introduced the possibility of the `CommutatorBound` containing a `NaN` value. The `min()` function did not account for that, resulting in NaN bounds overall. This fixes that regression.