### PR TITLE
feat: add `qiskit_addon_slc.globals.PROGRESS_POLLING_RATE`

### DIFF
--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -33,7 +33,7 @@ from qiskit.quantum_info import (
     SparsePauliOp,
 )
 
-from ..globals import ZERO_ATOL
+from .. import globals as slc_globals
 from ..utils import remove_measure
 from .commutator_bounds import Bounds, CommutatorBounds, compute_bounds
 from .light_cone import LightCone
@@ -79,7 +79,7 @@ def _time_evolved_norm_backward(
         operator=pauli,
         rot_gates=gates,
         max_terms=evolution_max_terms,
-        atol=ZERO_ATOL,
+        atol=slc_globals.ZERO_ATOL,
         frame="s",
     )
     trunc_bias = 2 * trunc_onenorm

--- a/qiskit_addon_slc/bounds/commutator_bounds.py
+++ b/qiskit_addon_slc/bounds/commutator_bounds.py
@@ -40,6 +40,7 @@ from qiskit.quantum_info import (
     SparsePauliOp,
 )
 
+from .. import globals as slc_globals
 from ..utils import find_indices, iter_circuit
 from .light_cone import LightCone
 
@@ -242,13 +243,12 @@ def compute_bounds(
     total_num_tasks = len(tasks)
     LOGGER.info(f"Total number of spawned tasks: {total_num_tasks}")
 
-    progress_polling_rate = 1
     len_progress_indicator = 50
     per_progress_char = total_num_tasks / len_progress_indicator
 
     try:
         while tasks:
-            next(iter(tasks)).wait(progress_polling_rate)
+            next(iter(tasks)).wait(slc_globals.PROGRESS_POLLING_RATE)
             tasks = {t for t in tasks if not t.ready()}
             completed = total_num_tasks - len(tasks)
             perc = (completed / total_num_tasks) * 100

--- a/qiskit_addon_slc/bounds/forward.py
+++ b/qiskit_addon_slc/bounds/forward.py
@@ -37,7 +37,7 @@ from qiskit.quantum_info import (
 )
 from qiskit.utils import deprecate_arg
 
-from ..globals import ZERO_ATOL
+from .. import globals as slc_globals
 from ..utils import get_extremal_eigenvalue, remove_measure
 from .commutator_bounds import Bounds, CommutatorBounds, compute_bounds
 from .light_cone import LightCone
@@ -95,7 +95,7 @@ def time_evolved_norm_forward(
         operator=pauli,
         rot_gates=gates,
         max_terms=evolution_max_terms,
-        atol=ZERO_ATOL,
+        atol=slc_globals.ZERO_ATOL,
         frame="s",
     )
     trunc_bias = 2 * trunc_onenorm

--- a/qiskit_addon_slc/globals.py
+++ b/qiskit_addon_slc/globals.py
@@ -20,10 +20,19 @@
 
 This module provides a number of globally configurable settings.
 
+.. autoclass:: PROGRESS_POLLING_RATE
+
 .. autoclass:: ZERO_ATOL
 """
 
 import sys
+
+PROGRESS_POLLING_RATE = 1
+"""The polling rate for the progress indicator of the commutator bound task computation.
+
+This number corresponds to the number of seconds to wait between progress indicator updates.
+It defaults to ``1``.
+"""
 
 ZERO_ATOL = 10 * sys.float_info.epsilon
 """The absolute tolerance value below which terms are considered truly zero and are truncated.

--- a/releasenotes/notes/progress-polling-rate-096885bda27a33ac.yaml
+++ b/releasenotes/notes/progress-polling-rate-096885bda27a33ac.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The polling rate of the bound computation progress indicator can now be
+    configured via :attr:`qiskit_addon_slc.globals.PROGRESS_POLLING_RATE`.


### PR DESCRIPTION
Allowing configuring the polling rate of the bound computation progress indicator.