### PR TITLE
feat: more scalable way to expose compute_bounds kwargs

### DIFF
--- a/qiskit_addon_slc/bounds/__init__.py
+++ b/qiskit_addon_slc/bounds/__init__.py
@@ -30,16 +30,32 @@ lightcone.
 .. autofunction:: merge_bounds
 
 .. autofunction:: compute_local_scales
+
+----
+
+This module also contains some lower level functions which are usually not accessed by an end-user
+directly, but may prove useful for additional development on top of this package.
+
+.. autofunction:: compute_bounds
+
+.. autoclass:: CommutatorBounds
+   :members:
+   :no-inherited-members:
+   :no-special-members:
+   :show-inheritance:
 """
 
 from .backward import compute_backward_bounds
+from .commutator_bounds import CommutatorBounds, compute_bounds
 from .forward import compute_forward_bounds
 from .local_scales import compute_local_scales
 from .merge import merge_bounds
 from .speed_limit import tighten_with_speed_limit
 
 __all__ = [
+    "CommutatorBounds",
     "compute_backward_bounds",
+    "compute_bounds",
     "compute_forward_bounds",
     "compute_local_scales",
     "merge_bounds",

--- a/qiskit_addon_slc/bounds/backward.py
+++ b/qiskit_addon_slc/bounds/backward.py
@@ -107,9 +107,7 @@ def compute_backward_bounds(
     /,
     *,
     evolution_max_terms: int = 1_000_000,
-    max_num_boxes: int | None = None,
-    num_processes: int = 1,
-    timeout: float | None = None,
+    **kwargs,
 ) -> Bounds:
     r"""Compute the backward-evolved unequal-time commutator bounds.
 
@@ -137,12 +135,7 @@ def compute_backward_bounds(
         noise_model_paulis: the Pauli error terms to consider for each noise model.
         evolution_max_terms: the maximum number of operator terms to keep track of during the
             evolution. (If the operator exceeds this size, the smallest terms are truncated).
-        max_num_boxes: the maximum number of boxes for which to compute bounds. Bounds for any
-            additional boxes will be given the trivial upper bound value of :math:`2.0`.
-        num_processes: the number of parallel processes to use.
-        timeout: an optional timeout (in seconds) after which all remaining layers are filled with
-            trivial numerical bounds of ``2.0``. Note, that this is not a strict timeout and the
-            layer being processed at the time of reaching this timeout will complete normally.
+        kwargs: any additional keyword arguments will be forward to :func:`.compute_bounds`.
 
     Returns:
         The backward-evolved unequal-time commutator bounds.
@@ -165,9 +158,7 @@ def compute_backward_bounds(
         lc,
         norm_fn,
         backwards=True,
-        max_num_boxes=max_num_boxes,
-        num_processes=num_processes,
-        timeout=timeout,
+        **kwargs,
     )
 
     return comm_norms

--- a/qiskit_addon_slc/bounds/forward.py
+++ b/qiskit_addon_slc/bounds/forward.py
@@ -219,9 +219,7 @@ def compute_forward_bounds(
     atol: float = 1e-8,
     atol_simplify: float = 1e-8,
     atol_eigenvalue: float = 1e-8,
-    max_num_boxes: int | None = None,
-    num_processes: int = 1,
-    timeout: float | None = None,
+    **kwargs,
 ) -> Bounds:
     r"""Compute the forward-evolved unequal-time commutator bounds.
 
@@ -253,12 +251,7 @@ def compute_forward_bounds(
         atol_eigenvalue: the absolute tolerance used for detecting convergence of the commutator's
             eigenvalue. Loosening this tolerance will result in a less accurate eigenvalue as
             computed by the iterative Davidson eigensolver.
-        max_num_boxes: the maximum number of boxes for which to compute bounds. Bounds for any
-            additional boxes will be given the trivial upper bound value of :math:`2.0`.
-        num_processes: the number of parallel processes to use.
-        timeout: an optional timeout (in seconds) after which all remaining layers are filled with
-            trivial numerical bounds of ``2.0``. Note, that this is not a strict timeout and the
-            layer being processed at the time of reaching this timeout will complete normally.
+        kwargs: any additional keyword arguments will be forward to :func:`.compute_bounds`.
 
     Returns:
         The unequal-time commutator bound.
@@ -316,9 +309,7 @@ def compute_forward_bounds(
         lc,
         norm_fn,
         backwards=False,
-        max_num_boxes=max_num_boxes,
-        num_processes=num_processes,
-        timeout=timeout,
+        **kwargs,
     )
 
     return comm_norms


### PR DESCRIPTION
Rather than duplicating a bunch of arguments across the various functions for computing bounds, we now simply forward any unknown keyword arguments from higher level functions down to the lower level one.